### PR TITLE
Blink Datadog actions docs 404

### DIFF
--- a/blink/README.md
+++ b/blink/README.md
@@ -35,6 +35,6 @@ Need help? Contact [Datadog support][5].
 
 [1]: https://www.blinkops.com/
 [2]: https://library.blinkops.com/
-[3]: https://www.docs.blinkops.com/docs/Integrations/Datadog/Actions
-[4]: https://www.docs.blinkops.com/docs/Integrations/Datadog/
+[3]: https://www.docs.blinkops.com/docs/Integrations/datadog/actions/
+[4]: https://www.docs.blinkops.com/docs/Integrations/datadog/
 [5]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?

Fixed broken links to Blink Datadog actions documentation - the current ones are 404 pages.


### Motivation

Changes in Blink documentation routes.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)


